### PR TITLE
Make installable on PHP 8.1 and higher

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "vendic/magento2-clean-cron-schedule",
     "description": "Magento 2.2 has issues with giant `cron_schedule` tables. The cron job running time will increase when the table gets bigger, causing heavy CPU usage. ",
     "require": {
-        "php": "~7.0.0|~7.1.0|~7.2.0|~7.3.0|~7.4.0|~8.1.0|~8.2.0",
+        "php": "~7.0.0|~7.1.0|~7.2.0|~7.3.0|~7.4.0|^8.1",
         "magento/framework": "^101.0.0|^102.0.0|^103.0.0",
         "magento/magento-composer-installer": "*"
     },


### PR DESCRIPTION
New PHP subversions hardly ever break, remove the hard upper version constraint.